### PR TITLE
Migrate to newer sbt and sbt-assembly

### DIFF
--- a/assembly.sbt
+++ b/assembly.sbt
@@ -1,3 +1,0 @@
-import AssemblyKeys._ // put this at the top of the file
-
-assemblySettings

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import AssemblyKeys._ //一番最初の行に書く
-
 name := "HWS"
 
 version := "0.1.1"
@@ -8,6 +6,4 @@ scalaVersion := "2.10.4"
 
 mainClass in (Compile,run) := Some("main.scala.HWS")
 
-libraryDependencies <+= scalaVersion { "org.scala-lang" % "scala-swing" % _ }
-
-assemblySettings    //これを追加しますん
+libraryDependencies += scalaVersion { "org.scala-lang" % "scala-swing" % _ }.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
最新のsbtでは`sbt assembly`が通らないようだったので修正しました。
修正は以下のページを参考にしました
[sbt Reference Manual — Migrating from sbt 0.13.x](https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html)
[sbt-assembly/Migration.md at master · sbt/sbt-assembly](https://github.com/sbt/sbt-assembly/blob/master/Migration.md)

Scalaを触るのは初めてなので問題がありましたらお申し付けください。

---
課題でカルノー図を大量に書く羽目になっていたところに、使いやすいツールを見つけられてとても重宝しています。
このような便利なツールを作っていただきありがとうございます。